### PR TITLE
Bugfix: Typo in main.css .grails-logo-container

### DIFF
--- a/skeleton/grails-app/assets/stylesheets/main.css
+++ b/skeleton/grails-app/assets/stylesheets/main.css
@@ -565,7 +565,7 @@ a.skip {
     margin-bottom: 20px;
     color: white;
     height:300px;
-    text-align:center;"
+    text-align:center;
 }
 
 img.grails-logo {


### PR DESCRIPTION
There was a quote char typo in the class .grails-logo-container, which made it impossible to use css-code after the main.css was included.

Issue: https://github.com/grails-profiles/profile/issues/1