### PR TITLE
3.3.1 testing support templates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: "org.grails.grails-profile"
 apply plugin: "org.grails.grails-profile-publish"
 
 group 'org.grails.profiles'
-version '3.3.0.BUILD-SNAPSHOT'
+version '3.3.1.BUILD-SNAPSHOT'
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: "org.grails.grails-profile"
 apply plugin: "org.grails.grails-profile-publish"
 
 group 'org.grails.profiles'
-version '3.3.1.BUILD-SNAPSHOT'
+version '3.3.0.BUILD-SNAPSHOT'
 
 repositories {
     mavenLocal()

--- a/profile.yml
+++ b/profile.yml
@@ -27,7 +27,8 @@ dependencies:
         - "org.grails.plugins:scaffolding"      
     testCompile:
         - "org.grails:grails-plugin-testing"    
-        - "org.grails.plugins:geb"  
+        - "org.grails.plugins:geb"
+        - "org.grails:grails-web-testing-support"
     testRuntime:
         - 'org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1'
         - 'net.sourceforge.htmlunit:htmlunit:2.18'

--- a/templates/testing/Controller.groovy
+++ b/templates/testing/Controller.groovy
@@ -1,12 +1,8 @@
 @artifact.package@
-import grails.test.mixin.TestFor
+import grails.testing.web.controllers.ControllerUnitTest
 import spock.lang.Specification
 
-/**
- * See the API for {@link grails.test.mixin.web.ControllerUnitTestMixin} for usage instructions
- */
-@TestFor(@artifact.name@Controller)
-class @artifact.name@ControllerSpec extends Specification {
+class @artifact.name@ControllerSpec extends Specification implements ControllerUnitTest<@artifact.name@Controller>{
 
     def setup() {
     }

--- a/templates/testing/TagLib.groovy
+++ b/templates/testing/TagLib.groovy
@@ -1,12 +1,8 @@
 @artifact.package@
-import grails.test.mixin.TestFor
+import grails.testing.web.taglib.TagLibUnitTest
 import spock.lang.Specification
 
-/**
- * See the API for {@link grails.test.mixin.web.GroovyPageUnitTestMixin} for usage instructions
- */
-@TestFor(@artifact.name@TagLib)
-class @artifact.name@TagLibSpec extends Specification {
+class @artifact.name@TagLibSpec extends Specification implements TagLibUnitTest<@artifact.name@TagLib>{
 
     def setup() {
     }


### PR DESCRIPTION
simply updating the template while placing the dependency in - changes were tested with a local install of the profile onto a sample app
- the version is actually 3.3.0 even though i mistakenly named the branch 3.3.1