### PR TITLE
drop deprecated unique-names reference

### DIFF
--- a/skeleton/grails-app/conf/application.yml
+++ b/skeleton/grails-app/conf/application.yml
@@ -49,7 +49,3 @@ grails:
                 scriptlet: html
                 taglib: none
                 staticparts: none
-management:
-    endpoints:
-        jmx:
-            unique-names: true


### PR DESCRIPTION
default grails 4.0.12 app has unique-names twice in application.yml dropping the second set per the upgrading to Grails 4 documentation.

management:
endpoints:
jmx:
unique-names: true

https://stackoverflow.com/questions/69587357/default-grails-4-app-has-unique-names-twice-in-application-yml

https://docs.grails.org/latest/guide/upgrading.html#upgrading40x