### PR TITLE
Fixed WARN: get profile from config in index.gsp

### DIFF
--- a/skeleton/grails-app/views/index.gsp
+++ b/skeleton/grails-app/views/index.gsp
@@ -10,7 +10,7 @@
         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Environment: ${grails.util.Environment.current.name}</a></li>
-            <li class="dropdown-item"><a href="#">App profile: ${grailsApplication.config.grails?.profile}</a></li>
+            <li class="dropdown-item"><a href="#">App profile: ${grailsApplication.config.getProperty('grails.profile')}</a></li>
             <li class="dropdown-item"><a href="#">App version:
                 <g:meta name="info.app.version"/></a>
             </li>


### PR DESCRIPTION
Remove Config WARN,
Accessing config key 'profile' through dot notation is deprecated, and it will be removed in a future release. Use 'config.getProperty(key, targetClass)' instead.